### PR TITLE
don't break app in new versions of paperclip

### DIFF
--- a/lib/paperclip/rack/io_adapters/file_adapter.rb
+++ b/lib/paperclip/rack/io_adapters/file_adapter.rb
@@ -1,7 +1,7 @@
 module Paperclip
   module Rack
     class FileAdapter < ::Paperclip::AbstractAdapter
-      def initialize(target)
+      def initialize(target, hash_digest)
         @target = target[:tempfile]
         cache_current_values(target)
       end


### PR DESCRIPTION
Paperclip now sends an `hash_digest`, as documented in the github's [checksum / fingerprint](https://github.com/adalbertoteixeira/paperclip-rack.git) section.

Without this we were getting an `expected 2 got 1` error.